### PR TITLE
Change sleep_time from 2s to 1s

### DIFF
--- a/confcrawl/emnlp.py
+++ b/confcrawl/emnlp.py
@@ -57,7 +57,7 @@ def emnlp_2020(save_dir: Optional[str] = None) -> None:
     ):
         result["title"].append(long_title)
         result["author"].append(long_author)
-        arxiv = search_google(long_title, sleep_time=2)
+        arxiv = search_google(long_title, sleep_time=1)
         result["arxiv"].append(arxiv)
         result["type"].append("long")
 
@@ -66,7 +66,7 @@ def emnlp_2020(save_dir: Optional[str] = None) -> None:
     ):
         result["title"].append(short_title)
         result["author"].append(short_author)
-        arxiv = search_google(short_title, sleep_time=2)
+        arxiv = search_google(short_title, sleep_time=1)
         result["arxiv"].append(arxiv)
         result["type"].append("short")
 


### PR DESCRIPTION
Hi:)

In code, `sleep_time` for crawling is **2 seconds**. But the interval seems quite long, so I've tested some experiment for `sleep_time`.

----

I've called the script as below, with changing `sleep_time`. (`0.5`, `0.7`, `1.0`, `1.5`) 

```bash
#!/bin/bash
python crawl.py --conf emnlp --year 2020
python crawl.py --conf emnlp --year 2020
python crawl.py --conf emnlp --year 2020
python crawl.py --conf emnlp --year 2020
```

- If `sleep_time=0.5`, **the crawler got banned**. (approximately at the third time of calling the python script)
  - Until `0.7`, crawler isn't banned. But I've set the `sleep_time=1` for safety. (Actually changing `sleep_time` from 0.7 to 1.0 won't increase total time dramatically.)
- Crawling ban lasts for **12 hours**.


Thank you:)